### PR TITLE
.pgpass for local user

### DIFF
--- a/centos-automate-workflow.sh
+++ b/centos-automate-workflow.sh
@@ -74,11 +74,11 @@ echo "${dbname} was backed up at \$(date "+%Y_%m_%d_%H_%M") into \"${backupDirec
 EOF
 
 # To make sure that this backup script will run without a password, we need to add a .pgpass file to ~ if it doesn't already exist:
-if [ ! -f /home/$USER/.pgpass ]; then
-	touch /home/$USER/.pgpass
-	echo "localhost:5432:*:postgres:DaVinci" > /home/$USER/.pgpass
+if [ ! -f $HOME/.pgpass ]; then
+	touch $HOME/.pgpass
+	echo "localhost:5432:*:postgres:DaVinci" > $HOME/.pgpass
 # 	We also need to make sure that that .pgpass file has the correct permissions of 0600:
-	chmod 0600 /home/$USER/.pgpass
+	chmod 0600 $HOME/.pgpass
 fi
 
 # Let's move onto the "optimize" script:


### PR DESCRIPTION
This is a fix for the old _bad_ code that had specified `/home/$USER`, for the location of the `.pgpass` file thus causing the script to throw an error when `sudo` was used, because the script was looking for the `root` user's `.pgpass` file. Since there is none--and there isn't supposed to be, I replaced all instances of `/home/$USER` with `$HOME`, which properly references the non-root user that's supposed to have the `.pgpass` file, even when `sudo` is used.