### PR TITLE
Improve special character handling in database names

### DIFF
--- a/enterprise-linux-install.sh
+++ b/enterprise-linux-install.sh
@@ -1,11 +1,16 @@
 #!/bin/bash
 
+PATH_TOOLS="/usr/local/DaVinci-Resolve-PostgreSQL-Workflow-Tools"
+
 # Here's where the user is going to enter the Resolve database name, as it appears in the GUI:
 read -p "Enter the name of your DaVinci Resolve PostgreSQL database: " dbname
 
 # Let's allow the user to confirm that what they've typed in is correct:
 echo "You entered: $dbname"
-read -p "Is that correct? Enter y or n: " confirm && [[ $confirm == [yY] || $confirm == [yY][eE][sS] ]] || exit 1 
+read -p "Is that correct? Enter y or n: " confirm && [[ $confirm == [yY] || $confirm == [yY][eE][sS] ]] || exit 1
+
+# Create a sanitized version of the database name for use in related filenames
+pathname=$(printf %s "$dbname" | tr -Cs "[:alnum:]" "_")
 
 # Now "$dbname" will work as a variable in subsequent paths.
 
@@ -37,40 +42,40 @@ read -p "How often would you like to optimize the database? " optimizeFrequency
 read -p "You entered that you want to optimize your database every "$optimizeFrequency". Is that correct? Enter y or n: " confirm && [[ $confirm == [yY] || $confirm == [yY][eE][sS] ]] || exit 1
 
 # Let's check if a /usr/local/DaVinci-Resolve-PostgreSQL-Workflow-Tools folder exists, and if it doesn't, let's create one:
-mkdir -p /usr/local/DaVinci-Resolve-PostgreSQL-Workflow-Tools
+mkdir -p "${PATH_TOOLS}"
 
 # Let's also check to see if there are separate directories for "backup" and "optimize" scripts, and if they don't exist, let's create them.
 # We're making separate directories for the different kinds of scripts just to keep everything clean and organized.
 
-mkdir -p /usr/local/DaVinci-Resolve-PostgreSQL-Workflow-Tools/backup
-mkdir -p /usr/local/DaVinci-Resolve-PostgreSQL-Workflow-Tools/optimize
+mkdir -p "${PATH_TOOLS}/backup"
+mkdir -p "${PATH_TOOLS}/optimize"
 
 # Let's also make a folder for log files
-mkdir -p /usr/local/DaVinci-Resolve-PostgreSQL-Workflow-Tools/logs
+mkdir -p "${PATH_TOOLS}/logs"
 
 
 # We also need to make sure that these folders in which the scripts are living have the proper permissions to execute:
-chmod -R 755 /usr/local/DaVinci-Resolve-PostgreSQL-Workflow-Tools/backup
-chmod -R 755 /usr/local/DaVinci-Resolve-PostgreSQL-Workflow-Tools/optimize
-chmod -R 777 /usr/local/DaVinci-Resolve-PostgreSQL-Workflow-Tools/logs
+chmod -R 755 "${PATH_TOOLS}/backup"
+chmod -R 755 "${PATH_TOOLS}/optimize"
+chmod -R 777 "${PATH_TOOLS}/logs"
 
 # Let's make sure a log file exists if it doesn't already
-touch /usr/local/DaVinci-Resolve-PostgreSQL-Workflow-Tools/logs/logs-$(date +%Y_%m).log
+touch "${PATH_TOOLS}/logs/logs-$(date +%Y_%m).log"
 
 # Let's make sure that that log file can be read from and written to
-chmod 777 /usr/local/DaVinci-Resolve-PostgreSQL-Workflow-Tools/logs/logs-$(date +%Y_%m).log
+chmod 777 "${PATH_TOOLS}/logs/logs-$(date +%Y_%m).log"
 
 # Let's go ahead and create the two different shell scripts that will be executed by the systemd files.
 
 # First, let's create the "backup" shell script:
-touch /usr/local/DaVinci-Resolve-PostgreSQL-Workflow-Tools/backup/backup-"$dbname".sh
+touch "${PATH_TOOLS}/backup/backup-${pathname}.sh"
 
 # Now, let's fill it in:
-cat << EOF > /usr/local/DaVinci-Resolve-PostgreSQL-Workflow-Tools/backup/backup-"$dbname".sh
+cat << EOF > "${PATH_TOOLS}/backup/backup-${pathname}.sh"
 #!/bin/bash
 # Let's perform the backup and log to the monthly log file if the backup is successful.
-/usr/pgsql-13/bin/pg_dump --host localhost --username postgres $dbname --blobs --file $backupDirectory/${dbname}_\$(date "+%Y_%m_%d_%H_%M").backup --format=custom --verbose --no-password && \\
-echo "${dbname} was backed up at \$(date "+%Y_%m_%d_%H_%M") into \"${backupDirectory}\"." >> /usr/local/DaVinci-Resolve-PostgreSQL-Workflow-Tools/logs/logs-\$(date "+%Y_%m").log
+/usr/pgsql-13/bin/pg_dump --host localhost --username postgres "$dbname" --blobs --file "${backupDirectory}/${pathname}_\$(date "+%Y_%m_%d_%H_%M").backup" --format=custom --verbose --no-password && \\
+echo "${dbname} was backed up at \$(date "+%Y_%m_%d_%H_%M") into "${backupDirectory}"." >> "${PATH_TOOLS}/logs/logs-\$(date "+%Y_%m").log"
 EOF
 
 # To make sure that this backup script will run without a password, we need to add a .pgpass file to ~ if it doesn't already exist:
@@ -82,34 +87,34 @@ if [ ! -f /root/.pgpass ]; then
 fi
 
 # Let's move onto the "optimize" script:
-touch /usr/local/DaVinci-Resolve-PostgreSQL-Workflow-Tools/optimize/optimize-"$dbname".sh
-cat << EOF > /usr/local/DaVinci-Resolve-PostgreSQL-Workflow-Tools/optimize/optimize-"$dbname".sh
+touch "${PATH_TOOLS}/optimize/optimize-${pathname}.sh"
+cat << EOF > "${PATH_TOOLS}/optimize/optimize-${pathname}.sh"
 #!/bin/bash
 # Let's optimize the database and log to the monthly log file if the optimization is successful.
 /usr/pgsql-13/bin/reindexdb --host localhost --username postgres $dbname --no-password --echo && \\
 /usr/pgsql-13/bin/vacuumdb --analyze --host localhost --username postgres $dbname --verbose --no-password && \\
-echo "${dbname} was optimized at \$(date "+%Y_%m_%d_%H_%M")." >> /usr/local/DaVinci-Resolve-PostgreSQL-Workflow-Tools/logs/logs-\$(date "+%Y_%m").log
+echo "${dbname} was optimized at \$(date "+%Y_%m_%d_%H_%M")." >> "${PATH_TOOLS}/logs/logs-\$(date "+%Y_%m").log"
 EOF
 
 # Now each individual shell script needs to have their permissions set properly for systemd to read and execute the scripts, so let's use 755:
-chmod 755 /usr/local/DaVinci-Resolve-PostgreSQL-Workflow-Tools/backup/backup-"$dbname".sh
-chmod 755 /usr/local/DaVinci-Resolve-PostgreSQL-Workflow-Tools/optimize/optimize-"$dbname".sh
+chmod 755 "${PATH_TOOLS}/backup/backup-${pathname}.sh"
+chmod 755 "${PATH_TOOLS}/optimize/optimize-${pathname}.sh"
 
 # With both shell scripts created with the proper permissions, we can create, load, and start the systemd services and timers.
 
 # Let's create the "backup" service and timer first.
-touch /etc/systemd/system/backup-"$dbname".service
-cat << EOF > /etc/systemd/system/backup-"$dbname".service
+touch /etc/systemd/system/backup-${pathname}.service
+cat << EOF > /etc/systemd/system/backup-${pathname}.service
 [Unit]
 Description=Backup of $dbname DaVinci Resolve PostgreSQL database
 
 [Service]
 Type=oneshot
-ExecStart=/usr/local/DaVinci-Resolve-PostgreSQL-Workflow-Tools/backup/backup-$dbname.sh
+ExecStart=${PATH_TOOLS}/backup/backup-${pathname}.sh
 EOF
 
-touch /etc/systemd/system/backup-"$dbname".timer
-cat << EOF > /etc/systemd/system/backup-"$dbname".timer
+touch /etc/systemd/system/backup-${pathname}.timer
+cat << EOF > /etc/systemd/system/backup-${pathname}.timer
 [Unit]
 Description=Backup of $dbname DaVinci Resolve PostgreSQL database
 
@@ -124,18 +129,18 @@ WantedBy=timers.target
 EOF
 
 # Now let's create the "optimize" service and timer.
-touch /etc/systemd/system/optimize-"$dbname".service
-cat << EOF > /etc/systemd/system/optimize-"$dbname".service
+touch /etc/systemd/system/optimize-${pathname}.service
+cat << EOF > /etc/systemd/system/optimize-${pathname}.service
 [Unit]
 Description=Optimize $dbname DaVinci Resolve PostgreSQL database
 
 [Service]
 Type=oneshot
-ExecStart=/usr/local/DaVinci-Resolve-PostgreSQL-Workflow-Tools/optimize/optimize-$dbname.sh
+ExecStart=${PATH_TOOLS}/optimize/optimize-${pathname}.sh
 EOF
 
-touch /etc/systemd/system/optimize-"$dbname".timer
-cat << EOF > /etc/systemd/system/optimize-"$dbname".timer
+touch /etc/systemd/system/optimize-${pathname}.timer
+cat << EOF > /etc/systemd/system/optimize-${pathname}.timer
 [Unit]
 Description=Optimize $dbname DaVinci Resolve PostgreSQL database
 
@@ -150,18 +155,18 @@ WantedBy=timers.target
 EOF
 
 # These systemd files each need permissions of 755.
-chmod 755 /etc/systemd/system/backup-"$dbname".service
-chmod 755 /etc/systemd/system/backup-"$dbname".timer
-chmod 755 /etc/systemd/system/optimize-"$dbname".service
-chmod 755 /etc/systemd/system/optimize-"$dbname".timer
+chmod 755 /etc/systemd/system/backup-${pathname}.service
+chmod 755 /etc/systemd/system/backup-${pathname}.timer
+chmod 755 /etc/systemd/system/optimize-${pathname}.service
+chmod 755 /etc/systemd/system/optimize-${pathname}.timer
 
 # Now, the "backup" and "optimize" scripts and systemd files are in place.
 # All we need to do is enable and start the timers.
 
 systemctl daemon-reload
-systemctl enable --now backup-"$dbname".timer
-systemctl enable --now optimize-"$dbname".timer
+systemctl enable --now backup-${pathname}.timer
+systemctl enable --now optimize-${pathname}.timer
 
 echo "Congratulations, $dbname will be backed up every "$backupFrequency" and optimized every "$optimizeFrequency"."
-echo "You can check to make sure that everything is being backed up and optimized properly by periodically looking at the log files in: /usr/local/DaVinci-Resolve-PostgreSQL-Workflow-Tools/logs"
+echo "You can check to make sure that everything is being backed up and optimized properly by periodically looking at the log files in: ${PATH_TOOLS}/logs"
 echo "Have a great day!"

--- a/enterprise-linux-uninstall.sh
+++ b/enterprise-linux-uninstall.sh
@@ -7,47 +7,50 @@ read -p "What is the name of the database for which you'd like to stop automatic
 echo "You entered: $dbname"
 read -p "Is that correct? Enter y or no: " confirm && [[ $confirm == [yY] || $confirm == [yY][eE][sS] ]] || exit 1
 
+# Create a sanitized version of the database name for use in related filenames
+pathname=$(printf %s "$dbname" | tr -Cs "[:alnum:]" "_")
+
 # stop backup systemd timer
-systemctl stop backup-"$dbname".timer
+systemctl stop backup-${pathname}.timer
 
 # stop backup systemd service
-systemctl stop backup-"$dbname".service
+systemctl stop backup-${pathname}.service
 
 # stop optimize systemd timer
-systemctl stop optimize-"$dbname".timer
+systemctl stop optimize-${pathname}.timer
 
 # stop optimize systemd service
-systemctl stop optimize-"$dbname."service
+systemctl stop optimize-${pathname}.service
 
 # disable backup systemd timer
-systemctl disable backup-"$dbname".timer
+systemctl disable backup-${pathname}.timer
 
 # disable backup systemd service
-systemctl disable backup-"$dbname".service
+systemctl disable backup-${pathname}.service
 
 # disable optimize systemd timer
-systemctl disable optimize-"$dbname".timer
+systemctl disable optimize-${pathname}.timer
 
 # disable optimize systemd service
-systemctl disable optimize-"$dbname".service
+systemctl disable optimize-${pathname}.service
 
 # remove backup systemd timer file
-rm /etc/systemd/system/backup-"$dbname".timer
+rm /etc/systemd/system/backup-${pathname}.timer
 
 # remove backup systemd service file
-rm /etc/systemd/system/backup-"$dbname".service
+rm /etc/systemd/system/backup-${pathname}.service
 
 # remove optimize systemd timer file
-rm /etc/systemd/system/optimize-"$dbname".timer
+rm /etc/systemd/system/optimize-${pathname}.timer
 
 # remove optimize systemd service file
-rm /etc/systemd/system/optimize-"$dbname".service
+rm /etc/systemd/system/optimize-${pathname}.service
 
 # remove backup shell script
-rm /usr/local/DaVinci-Resolve-PostgreSQL-Workflow-Tools/backup/backup-"$dbname".sh
+rm /usr/local/DaVinci-Resolve-PostgreSQL-Workflow-Tools/backup/backup-${pathname}.sh
 
 # remove optimize shell script
-rm /usr/local/DaVinci-Resolve-PostgreSQL-Workflow-Tools/optimize/optimize-"$dbname".sh
+rm /usr/local/DaVinci-Resolve-PostgreSQL-Workflow-Tools/optimize/optimize-${pathname}.sh
 
 # log to monthly log file that $dbname has been uninstalled. $dbname will no longer be backed up or optimized
 echo "Backup and optimize tools for $dbname were uninstalled at $(date "+%Y_%m_%d_%H_%M"). $dbname will no longer be backed up or optimized." >> /usr/local/DaVinci-Resolve-PostgreSQL-Workflow-Tools/logs/logs-$(date "+%Y_%m").log

--- a/macos-install.sh
+++ b/macos-install.sh
@@ -174,5 +174,5 @@ launchctl load "/Library/LaunchDaemons/optimize-${pathname}.plist"
 launchctl start com.resolve.optimize.${pathname}
 
 echo "Congratulations, ${dbname} will be backed up every $backupFrequency seconds and optimized every $optimizeFrequency seconds."
-echo "You can check to make sure that everything is being backed up and optimized properly by periodically looking at the log files in: "${PATH_TOOLS}/logs"
+echo "You can check to make sure that everything is being backed up and optimized properly by periodically looking at the log files in: ${PATH_TOOLS}/logs"
 echo "Have a great day!"

--- a/macos-install.sh
+++ b/macos-install.sh
@@ -84,10 +84,10 @@ touch "${PATH_TOOLS}/logs/logs-\${curr_date_short}.log" && \\
 chmod 777 "${PATH_TOOLS}/logs/logs-\${curr_date_short}.log" && \\ 
 
 # Let's perform the backup and log to the monthly log file if the backup is successful.
-/Library/PostgreSQL/13/bin/pg_dump --host localhost --username postgres "$dbname" --blobs --file "$backupDirectory/${pathname}_\$(date "+%Y_%m_%d_%H_%M").backup --format=custom --verbose --no-password && \\
+/Library/PostgreSQL/13/bin/pg_dump --host localhost --username postgres "$dbname" --blobs --file "${backupDirectory}/${pathname}_\$(date "+%Y_%m_%d_%H_%M").backup" --format=custom --verbose --no-password && \\
 
 # Log to the log file
-echo "${dbname} was backed up at \$(date "+%Y_%m_%d_%H_%M") into "$backupDirectory"." >> "${PATH_TOOLS}/logs/logs-\${curr_date_short}.log
+echo "${dbname} was backed up at \$(date "+%Y_%m_%d_%H_%M") into ${backupDirectory}." >> "${PATH_TOOLS}/logs/logs-\${curr_date_short}.log"
 EOF
 
 # To make sure that this backup script will run from the root account without a password, we need to add a .pgpass file to /var/root if it doesn't already exist:

--- a/macos-install.sh
+++ b/macos-install.sh
@@ -162,8 +162,6 @@ EOF
 chmod 755 "/Library/LaunchDaemons/backup-${pathname}.plist"
 chmod 755 "/Library/LaunchDaemons/optimize-${pathname}.plist"
 
-exit
-
 # Now, the "backup" and "optimize" scripts and daemons are in place.
 # All we need to do is load these daemons into launchd and start them with launchctl.
 

--- a/macos-install.sh
+++ b/macos-install.sh
@@ -1,13 +1,18 @@
 #!/bin/bash
 
+PATH_TOOLS="/Users/Shared/DaVinci-Resolve-PostgreSQL-Workflow-Tools"
+
 # Here's where the user is going to enter the Resolve database name, as it appears in the GUI:
 read -p "Enter the name of your DaVinci Resolve PostgreSQL database: " dbname
 
 # Let's allow the user to confirm that what they've typed in is correct:
 echo "You entered: $dbname"
-read -p "Is that correct? Enter y or n: " confirm && [[ $confirm == [yY] || $confirm == [yY][eE][sS] ]] || exit 1 
+read -p "Is that correct? Enter y or n: " confirm && [[ $confirm == [yY] || $confirm == [yY][eE][sS] ]] || exit 1
 
-# Now "$dbname" will work as a variable in subsequent paths.
+# Create a sanitized version of the database name for use in related filenames
+pathname=$(printf %s "$dbname" | tr -Cs "[:alnum:]" "_")
+
+# Now "$pathname" will work as a variable in subsequent paths.
 
 # Let's prompt the user for the "backup directory," which is where the backups from pg_dump will go:
 read -e -p "Into which directory should the database backups go? You can drag-and-drop a folder from Finder into Terminal. " backupDirectory
@@ -44,42 +49,45 @@ read -p "How often would you like to optimize the database, in seconds? " optimi
 # Let's have the user confirm that they entered the correct optimizing frequency:
 read -p "You entered that you want to optimize your database every $optimizeFrequency seconds. Is that correct? Enter y or n: " confirm && [[ $confirm == [yY] || $confirm == [yY][eE][sS] ]] || exit 1
 
-# Let's check if a /Users/Shared/DaVinci-Resolve-PostgreSQL-Workflow-Tools folder exists, and if it doesn't, let's create one:
-mkdir -p /Users/Shared/DaVinci-Resolve-PostgreSQL-Workflow-Tools
+# Let's check if a "${PATH_TOOLS} folder exists, and if it doesn't, let's create one:
+mkdir -p "$PATH_TOOLS"
 
 # Let's also check to see if there are separate directories for "backup" and "optimize" scripts, and if they don't exist, let's create them.
 # We're making separate directories for the different kinds of scripts just to keep everything clean and organized.
 
-mkdir -p /Users/Shared/DaVinci-Resolve-PostgreSQL-Workflow-Tools/backup
-mkdir -p /Users/Shared/DaVinci-Resolve-PostgreSQL-Workflow-Tools/optimize
+mkdir -p "${PATH_TOOLS}/backup"
+mkdir -p "${PATH_TOOLS}/optimize"
 
 # Let's also make a folder for log files
-mkdir -p /Users/Shared/DaVinci-Resolve-PostgreSQL-Workflow-Tools/logs
+mkdir -p "${PATH_TOOLS}/logs"
 
 # We also need to make sure that these folders in which the scripts are living have the proper permissions to execute:
-chmod -R 755 /Users/Shared/DaVinci-Resolve-PostgreSQL-Workflow-Tools/backup
-chmod -R 755 /Users/Shared/DaVinci-Resolve-PostgreSQL-Workflow-Tools/optimize
-chmod -R 777 /Users/Shared/DaVinci-Resolve-PostgreSQL-Workflow-Tools/logs
+chmod -R 755 "${PATH_TOOLS}/backup"
+chmod -R 755 "${PATH_TOOLS}/optimize"
+chmod -R 777 "${PATH_TOOLS}/logs"
 
 # With all these folders created, with the correct permissions, we can go ahead and create the two different shell scripts that will be executed by the launchd XML files.
 
 # First, let's create the "backup" shell script:
-touch /Users/Shared/DaVinci-Resolve-PostgreSQL-Workflow-Tools/backup/backup-"$dbname".sh
+touch "${PATH_TOOLS}/backup/backup-${pathname}.sh"
 
 # Now, let's fill it in:
-cat << EOF > /Users/Shared/DaVinci-Resolve-PostgreSQL-Workflow-Tools/backup/backup-"$dbname".sh
+cat << EOF > "${PATH_TOOLS}/backup/backup-${pathname}.sh"
 #!/bin/bash
+
+curr_date_short=\$(date "+%Y_%m") && \\
+
 # Check to make sure that the log file exists
-touch /Users/Shared/DaVinci-Resolve-PostgreSQL-Workflow-Tools/logs/logs-\$(date "+%Y_%m").log && \\
+touch "${PATH_TOOLS}/logs/logs-\${curr_date_short}.log" && \\
 
 # Make sure that the file can be written to
-chmod 777 /Users/Shared/DaVinci-Resolve-PostgreSQL-Workflow-Tools/logs/logs-\$(date "+%Y_%m").log && \\ 
+chmod 777 "${PATH_TOOLS}/logs/logs-\${curr_date_short}.log" && \\ 
 
 # Let's perform the backup and log to the monthly log file if the backup is successful.
-/Library/PostgreSQL/13/bin/pg_dump --host localhost --username postgres $dbname --blobs --file "$backupDirectory"/${dbname}_\$(date "+%Y_%m_%d_%H_%M").backup --format=custom --verbose --no-password && \\
+/Library/PostgreSQL/13/bin/pg_dump --host localhost --username postgres "$dbname" --blobs --file "$backupDirectory/${pathname}_\$(date "+%Y_%m_%d_%H_%M").backup --format=custom --verbose --no-password && \\
 
 # Log to the log file
-echo "${dbname} was backed up at \$(date "+%Y_%m_%d_%H_%M") into "$backupDirectory"." >> /Users/Shared/DaVinci-Resolve-PostgreSQL-Workflow-Tools/logs/logs-\$(date "+%Y_%m").log
+echo "${dbname} was backed up at \$(date "+%Y_%m_%d_%H_%M") into "$backupDirectory"." >> "${PATH_TOOLS}/logs/logs-\${curr_date_short}.log
 EOF
 
 # To make sure that this backup script will run from the root account without a password, we need to add a .pgpass file to /var/root if it doesn't already exist:
@@ -91,40 +99,42 @@ if [ ! -f /var/root/.pgpass ]; then
 fi
 
 # Let's move onto the "optimize" script:
-touch /Users/Shared/DaVinci-Resolve-PostgreSQL-Workflow-Tools/optimize/optimize-"$dbname".sh
-cat << EOF > /Users/Shared/DaVinci-Resolve-PostgreSQL-Workflow-Tools/optimize/optimize-"$dbname".sh
+touch "${PATH_TOOLS}/optimize/optimize-${pathname}.sh"
+cat << EOF > "${PATH_TOOLS}/optimize/optimize-${pathname}.sh"
 #!/bin/bash
 # Let's optimize the database and log to the monthly log file if the optimization is successful.
 
+curr_date_short=\$(date "+%Y_%m") && \\
+
 # Check to make sure that the log file exists
-touch /Users/Shared/DaVinci-Resolve-PostgreSQL-Workflow-Tools/logs/logs-\$(date "+%Y_%m").log && \\
+touch "${PATH_TOOLS}/logs/logs-\${curr_date_short}.log" && \\
 
 # Make sure that the file can be written to
-chmod 777 /Users/Shared/DaVinci-Resolve-PostgreSQL-Workflow-Tools/logs/logs-\$(date "+%Y_%m").log && \\ 
+chmod 777 "${PATH_TOOLS}/logs/logs-\${curr_date_short}.log" && \\ 
 
 # Perform the two "optimize" functions and log to the log file
-/Library/PostgreSQL/13/bin/reindexdb --host localhost --username postgres $dbname --no-password --echo && \\
-/Library/PostgreSQL/13/bin/vacuumdb --analyze --host localhost --username postgres $dbname --verbose --no-password && \\
-echo "${dbname} was optimized at \$(date "+%Y_%m_%d_%H_%M")." >> /Users/Shared/DaVinci-Resolve-PostgreSQL-Workflow-Tools/logs/logs-\$(date "+%Y_%m").log
+/Library/PostgreSQL/13/bin/reindexdb --host localhost --username postgres "$dbname" --no-password --echo && \\
+/Library/PostgreSQL/13/bin/vacuumdb --analyze --host localhost --username postgres "$dbname" --verbose --no-password && \\
+echo "${dbname} was optimized at \$(date "+%Y_%m_%d_%H_%M")." >> "${PATH_TOOLS}/logs/logs-\${curr_date_short}.log"
 EOF
 
 # Now each individual shell script needs to have their permissions set properly for launchd to read and execute the scripts, so let's use 755:
-chmod 755 /Users/Shared/DaVinci-Resolve-PostgreSQL-Workflow-Tools/backup/backup-"$dbname".sh
-chmod 755 /Users/Shared/DaVinci-Resolve-PostgreSQL-Workflow-Tools/optimize/optimize-"$dbname".sh
+chmod 755 "${PATH_TOOLS}/backup/backup-${pathname}.sh"
+chmod 755 "${PATH_TOOLS}/optimize/optimize-${pathname}.sh"
 
 # With both shell scripts created with the proper permissions, we can create, load, and start the two different launchd user daemons.
 
 # Let's create the "backup" daemon first.
-touch /Library/LaunchDaemons/backup-"$dbname".plist
-cat << EOF > /Library/LaunchDaemons/backup-"$dbname".plist
+touch "/Library/LaunchDaemons/backup-${pathname}.plist"
+cat << EOF > "/Library/LaunchDaemons/backup-${pathname}.plist"
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
     <key>Label</key>
-    <string>com.resolve.backup.$dbname</string>
+    <string>com.resolve.backup.${pathname}</string>
     <key>Program</key>
-        <string>/Users/Shared/DaVinci-Resolve-PostgreSQL-Workflow-Tools/backup/backup-$dbname.sh</string>
+        <string>${PATH_TOOLS}/backup/backup-${pathname}.sh</string>
     <key>StartInterval</key>
     <integer>$backupFrequency</integer>
 </dict>
@@ -132,16 +142,16 @@ cat << EOF > /Library/LaunchDaemons/backup-"$dbname".plist
 EOF
 
 # Now let's create the "optimize" daemon.
-touch /Library/LaunchDaemons/optimize-"$dbname".plist
-cat << EOF > /Library/LaunchDaemons/optimize-"$dbname".plist
+touch "/Library/LaunchDaemons/optimize-${pathname}.plist"
+cat << EOF > "/Library/LaunchDaemons/optimize-${pathname}.plist"
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
     <key>Label</key>
-    <string>com.resolve.optimize.$dbname</string>
+    <string>com.resolve.optimize.${pathname}</string>
     <key>Program</key>
-        <string>/Users/Shared/DaVinci-Resolve-PostgreSQL-Workflow-Tools/optimize/optimize-$dbname.sh</string>
+        <string>${PATH_TOOLS}/optimize/optimize-${pathname}.sh</string>
     <key>StartInterval</key>
     <integer>$optimizeFrequency</integer>
 </dict>
@@ -149,20 +159,22 @@ cat << EOF > /Library/LaunchDaemons/optimize-"$dbname".plist
 EOF
 
 # These plist files inside /Library/LaunchDaemons each need permissions of 755.
-chmod 755 /Library/LaunchDaemons/backup-"$dbname".plist
-chmod 755 /Library/LaunchDaemons/optimize-"$dbname".plist
+chmod 755 "/Library/LaunchDaemons/backup-${pathname}.plist"
+chmod 755 "/Library/LaunchDaemons/optimize-${pathname}.plist"
+
+exit
 
 # Now, the "backup" and "optimize" scripts and daemons are in place.
 # All we need to do is load these daemons into launchd and start them with launchctl.
 
 # First, let's load and start the backup daemon.
-launchctl load /Library/LaunchDaemons/backup-${dbname}.plist
-launchctl start com.resolve.backup.${dbname}
+launchctl load "/Library/LaunchDaemons/backup-${pathname}.plist"
+launchctl start com.resolve.backup.${pathname}
 
 # Lastly, let's load and start the optimize daemon.
-launchctl load /Library/LaunchDaemons/optimize-${dbname}.plist
-launchctl start com.resolve.optimize.${dbname}
+launchctl load "/Library/LaunchDaemons/optimize-${pathname}.plist"
+launchctl start com.resolve.optimize.${pathname}
 
-echo "Congratulations, $dbname will be backed up every $backupFrequency seconds and optimized every $optimizeFrequency seconds."
-echo "You can check to make sure that everything is being backed up and optimized properly by periodically looking at the log files in: /Users/Shared/DaVinci-Resolve-PostgreSQL-Workflow-Tools/logs"
+echo "Congratulations, ${dbname} will be backed up every $backupFrequency seconds and optimized every $optimizeFrequency seconds."
+echo "You can check to make sure that everything is being backed up and optimized properly by periodically looking at the log files in: "${PATH_TOOLS}/logs"
 echo "Have a great day!"

--- a/macos-uninstall.sh
+++ b/macos-uninstall.sh
@@ -7,29 +7,32 @@ read -p "What is the name of the database for which you'd like to stop automatic
 echo "You entered: $dbname"
 read -p "Is that correct? Enter y or no: " confirm && [[ $confirm == [yY] || $confirm == [yY][eE][sS] ]] || exit 1
 
+# Create a sanitized version of the database name for use in related filenames
+pathname=$(printf %s "$dbname" | tr -Cs "[:alnum:]" "_")
+
 # stop backup launchd job
-launchctl stop com.resolve.backup.$dbname
+launchctl stop com.resolve.backup.$pathname
 
 # unload backup plist file
-launchctl unload /Library/LaunchDaemons/backup-$dbname.plist
+launchctl unload /Library/LaunchDaemons/backup-$pathname.plist
 
 # stop optimize launchd job
-launchctl stop com.resolve.optimize.$dbname
+launchctl stop com.resolve.optimize.$pathname
 
 # unload optimize plist file
-launchctl unload /Library/LaunchDaemons/optimize-$dbname.plist
+launchctl unload /Library/LaunchDaemons/optimize-$pathname.plist
 
 # remove backup launchd plist file
-rm /Library/LaunchDaemons/backup-$dbname.plist
+rm /Library/LaunchDaemons/backup-$pathname.plist
 
 # remove optimize launchd plist file
-rm /Library/LaunchDaemons/optimize-$dbname.plist
+rm /Library/LaunchDaemons/optimize-$pathname.plist
 
 # remove backup shell script
-rm /Users/Shared/DaVinci-Resolve-PostgreSQL-Workflow-Tools/backup/backup-$dbname.sh
+rm /Users/Shared/DaVinci-Resolve-PostgreSQL-Workflow-Tools/backup/backup-$pathname.sh
 
 # remove optimize shell script
-rm /Users/Shared/DaVinci-Resolve-PostgreSQL-Workflow-Tools/optimize/optimize-$dbname.sh
+rm /Users/Shared/DaVinci-Resolve-PostgreSQL-Workflow-Tools/optimize/optimize-$pathname.sh
 
 # log to monthly log file that $dbname has been uninstalled. $dbname will no longer be backed up or optimized
 echo "Backup and optimize tools for $dbname were uninstalled at $(date "+%Y_%m_%d_%H_%M"). $dbname will no longer be backed up or optimized." >> /Users/Shared/DaVinci-Resolve-PostgreSQL-Workflow-Tools/logs/logs-$(date "+%Y_%m").log


### PR DESCRIPTION
Created a `$pathname` variable in the setup scripts, which replaces any non-alphanumeric characters with underscores.  This is used in resulting filenames and reverse-DNS job names.  Resolves (pun intended) issue #46 